### PR TITLE
Added maxelem 131070 parameter

### DIFF
--- a/build-country-sets.sh
+++ b/build-country-sets.sh
@@ -105,7 +105,7 @@ function build_ipv4_sets {
 
     #create ipset file if it doesn't exist
     if [[ ! -f $IPSET_FILE ]]; then
-      echo "create $SET_NAME hash:net comment" > $IPSET_FILE
+      echo "create $SET_NAME hash:net maxelem 131070 comment" > $IPSET_FILE
     fi
     echo "add ${SET_NAME} ${SUBNET} comment ${CC}" >> $IPSET_FILE
 


### PR DESCRIPTION
The US.ipv4 set already has 66062 entries, combined with the default maxelem of 65536 it ends up in "Error in line 65538: Hash is full, cannot add more elements" when trying to ipset restore. I did the same modification ofc on my own VPS and it works fine.

Name: US.ipv4
Type: hash:net
Revision: 6
Header: family inet hashsize 32768 maxelem 131070 comment
Size in memory: 3190357
References: 1
Number of entries: 66062