### PR TITLE
Calculate ipset maxelem instead of hardcoding

### DIFF
--- a/python/geoipsets/dbip.py
+++ b/python/geoipsets/dbip.py
@@ -96,7 +96,7 @@ class DbIpProvider(utils.AbstractProvider):
             if self.ip_tables:
                 ipset_path = self.base_dir / 'dbip/ipset' / ip_version / set_name
                 ipset_file = open(ipset_path, 'w')
-                maxelem = max(131072, 1 if len(subnets) == 0 else (2 << (len(subnets) - 1).bit_length()))
+                maxelem = max(131072, 1 if len(subnets) == 0 else (1 << (len(subnets) - 1).bit_length()))
                 ipset_file.write("create {0} hash:net {1} maxelem {2} comment\n".format(set_name, inet_family, maxelem))
 
             if self.nf_tables:

--- a/python/geoipsets/dbip.py
+++ b/python/geoipsets/dbip.py
@@ -96,7 +96,8 @@ class DbIpProvider(utils.AbstractProvider):
             if self.ip_tables:
                 ipset_path = self.base_dir / 'dbip/ipset' / ip_version / set_name
                 ipset_file = open(ipset_path, 'w')
-                ipset_file.write("create " + set_name + " hash:net " + inet_family + " maxelem 131072 comment\n")
+                maxelem = max(131072, 1 if len(subnets) == 0 else (2 << (len(subnets) - 1).bit_length()))
+                ipset_file.write("create {0} hash:net {1} maxelem {2} comment\n".format(set_name, inet_family, maxelem))
 
             if self.nf_tables:
                 nftset_path = self.base_dir / 'dbip/nftset' / ip_version / set_name

--- a/python/geoipsets/maxmind.py
+++ b/python/geoipsets/maxmind.py
@@ -168,8 +168,8 @@ class MaxMindProvider(utils.AbstractProvider):
                         ipset_file = ipset_dir / set_name
                         if not ipset_file.is_file():
                             with open(ipset_file, 'a') as f:
-                                # round up to the next next power of 2 for a load ratio < 0.5
-                                maxelem = max(131072, 1 if cc_counter[cc] == 0 else (2 << (cc_counter[cc] - 1).bit_length()))
+                                # round up to the next power of 2
+                                maxelem = max(131072, 1 if cc_counter[cc] == 0 else (1 << (cc_counter[cc] - 1).bit_length()))
                                 f.write("create {0} hash:net {1} maxelem {2} comment\n".format(set_name, inet_family, maxelem))
 
                         with open(ipset_file, 'a') as f:


### PR DESCRIPTION
The Maxmind US.ipv6 set contains more than 131072 entries as of now which will raise errors when trying to import. This PR counts the number of entry first and rounds up to the next next power of 2 to avoid allocating an ipset that is too small.