### PR TITLE
Improve systemd service sandboxing

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [ '*' ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ 'main' ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ ExecStart=/usr/bin/nft --file /usr/local/bin/refresh-sets.nft
 ```
 Where *refresh-sets.nft* contains the *nft* commands listed above.
 
+Note that the  [example systemd service file](https://github.com/chr0mag/geoipsets/blob/main/systemd/update-geoipsets.service) is heavily sandboxed and does not have privileges to restart network services by default. See the example file for instructions showing how to loosen restrictions to enable this.
 
 Performance
 -----------

--- a/python/geoipsets/maxmind.py
+++ b/python/geoipsets/maxmind.py
@@ -141,7 +141,8 @@ class MaxMindProvider(utils.AbstractProvider):
                 stream = TextIOWrapper(csv_file_bytes)
 
                 # count the number of entries for each country
-                cc_counter = Counter(country_code_map.get(r['geoname_id'] or r['registered_country_geoname_id']) for r in DictReader(stream))
+                cc_counter = Counter(country_code_map.get(r['geoname_id'] or r['registered_country_geoname_id'])
+                                     for r in DictReader(stream))
 
                 # return the stream to the start
                 stream.seek(0, 0)
@@ -169,8 +170,11 @@ class MaxMindProvider(utils.AbstractProvider):
                         if not ipset_file.is_file():
                             with open(ipset_file, 'a') as f:
                                 # round up to the next power of 2
-                                maxelem = max(131072, 1 if cc_counter[cc] == 0 else (1 << (cc_counter[cc] - 1).bit_length()))
-                                f.write("create {0} hash:net {1} maxelem {2} comment\n".format(set_name, inet_family, maxelem))
+                                maxelem = max(131072,
+                                              1 if cc_counter[cc] == 0 else (1 << (cc_counter[cc] - 1).bit_length()))
+                                f.write("create {0} hash:net {1} maxelem {2} comment\n".format(set_name,
+                                                                                               inet_family,
+                                                                                               maxelem))
 
                         with open(ipset_file, 'a') as f:
                             f.write("add " + set_name + " " + net + " comment " + cc + "\n")

--- a/systemd/update-geoipsets.service
+++ b/systemd/update-geoipsets.service
@@ -7,17 +7,29 @@ AssertPathExists=/var/local
 
 [Service]
 Type=oneshot
-CapabilityBoundingSet=~CAP_SYS_ADMIN
+CapabilityBoundingSet=
+RestrictAddressFamilies=AF_INET AF_INET6
+#if firewall configuration is updated as part of this service, replace the 2 lines above with the 2 lines below
+#CapabilityBoundingSet=CAP_NET_ADMIN
+#RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=true
 NoNewPrivileges=true
-ProtectProc=invisible
 PrivateDevices=true
 ProtectClock=true
-ProtectHome=read-only
-ProtectSystem=strict
-ReadWritePaths=/var/local /tmp
-InaccessiblePaths=-/lost+found
-NoExecPaths=/
-ExecPaths=/usr/bin/python /usr/bin/geoipsets /usr/bin/nft /usr/bin/ipset /usr/lib
+ProtectControlGroups=true
+ProtectHome=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProtectSystem=full
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+ProtectHostname=true
+LockPersonality=true
 ExecStart=/usr/bin/geoipsets --output-dir /var/local
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
The exposure level of the example systemd unit file is now a much more respectable 2.1.

```
% systemd-analyze security update-geoipsets.service --no-pager
  NAME                                                        DESCRIPTION                                                                            EXPOSURE
✗ PrivateNetwork=                                             Service has access to the host's network                                                    0.5
✗ User=/DynamicUser=                                          Service runs as root user                                                                   0.4
✓ CapabilityBoundingSet=~CAP_SET(UID|GID|PCAP)                Service cannot change UID/GID identities/capabilities                                          
✓ CapabilityBoundingSet=~CAP_SYS_ADMIN                        Service has no administrator privileges                                                        
✓ CapabilityBoundingSet=~CAP_SYS_PTRACE                       Service has no ptrace() debugging abilities                                                    
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                                       0.3
✓ RestrictNamespaces=~CLONE_NEWUSER                           Service cannot create user namespaces                                                          
✓ RestrictAddressFamilies=~…                                  Service cannot allocate exotic sockets                                                         
✓ CapabilityBoundingSet=~CAP_(CHOWN|FSETID|SETFCAP)           Service cannot change file ownership/access mode/capabilities                                  
✓ CapabilityBoundingSet=~CAP_(DAC_*|FOWNER|IPC_OWNER)         Service cannot override UNIX file/IPC permission checks                                        
✓ CapabilityBoundingSet=~CAP_NET_ADMIN                        Service has no network configuration privileges                                                
✓ CapabilityBoundingSet=~CAP_SYS_MODULE                       Service cannot load kernel modules                                                             
✓ CapabilityBoundingSet=~CAP_SYS_RAWIO                        Service has no raw I/O access                                                                  
✓ CapabilityBoundingSet=~CAP_SYS_TIME                         Service processes cannot change the system clock                                               
✗ DeviceAllow=                                                Service has a device ACL with some special devices                                          0.1
✗ IPAddressDeny=                                              Service does not define an IP address allow list                                            0.2
✓ KeyringMode=                                                Service doesn't share key material with other services                                         
✓ NoNewPrivileges=                                            Service processes cannot acquire new privileges                                                
✓ NotifyAccess=                                               Service child processes cannot alter service state                                             
✓ PrivateDevices=                                             Service has no access to hardware devices                                                      
✓ PrivateMounts=                                              Service cannot install system mounts                                                           
✗ PrivateTmp=                                                 Service has access to other software's temporary files                                      0.2
✗ PrivateUsers=                                               Service has access to other users                                                           0.2
✓ ProtectClock=                                               Service cannot write to the hardware clock or system clock                                     
✓ ProtectControlGroups=                                       Service cannot modify the control group file system                                            
✓ ProtectHome=                                                Service has no access to home directories                                                      
✓ ProtectKernelLogs=                                          Service cannot read from or write to the kernel log ring buffer                                
✓ ProtectKernelModules=                                       Service cannot load or read kernel modules                                                     
✓ ProtectKernelTunables=                                      Service cannot alter kernel tunables (/proc/sys, …)                                            
✓ ProtectProc=                                                Service has restricted access to process tree (/proc hidepid=)                                 
✗ ProtectSystem=                                              Service has very limited write access to the OS file hierarchy                              0.1
✓ RestrictAddressFamilies=~AF_PACKET                          Service cannot allocate packet sockets                                                         
✓ RestrictSUIDSGID=                                           SUID/SGID file creation by service is restricted                                               
✓ SystemCallArchitectures=                                    Service may execute system calls only with native ABI                                          
✓ SystemCallFilter=~@clock                                    System call allow list defined for service, and @clock is not included                         
✓ SystemCallFilter=~@debug                                    System call allow list defined for service, and @debug is not included                         
✓ SystemCallFilter=~@module                                   System call allow list defined for service, and @module is not included                        
✓ SystemCallFilter=~@mount                                    System call allow list defined for service, and @mount is not included                         
✓ SystemCallFilter=~@raw-io                                   System call allow list defined for service, and @raw-io is not included                        
✓ SystemCallFilter=~@reboot                                   System call allow list defined for service, and @reboot is not included                        
✓ SystemCallFilter=~@swap                                     System call allow list defined for service, and @swap is not included                          
✗ SystemCallFilter=~@privileged                               System call allow list defined for service, and @privileged is included (e.g. chown i…      0.2
✗ SystemCallFilter=~@resources                                System call allow list defined for service, and @resources is included (e.g. ioprio_s…      0.2
✓ AmbientCapabilities=                                        Service process does not receive ambient capabilities                                          
✓ CapabilityBoundingSet=~CAP_AUDIT_*                          Service has no audit subsystem access                                                          
✓ CapabilityBoundingSet=~CAP_KILL                             Service cannot send UNIX signals to arbitrary processes                                        
✓ CapabilityBoundingSet=~CAP_MKNOD                            Service cannot create device nodes                                                             
✓ CapabilityBoundingSet=~CAP_NET_(BIND_SERVICE|BROADCAST|RAW) Service has no elevated networking privileges                                                  
✓ CapabilityBoundingSet=~CAP_SYSLOG                           Service has no access to kernel logging                                                        
✓ CapabilityBoundingSet=~CAP_SYS_(NICE|RESOURCE)              Service has no privileges to change resource use parameters                                    
✓ RestrictNamespaces=~CLONE_NEWCGROUP                         Service cannot create cgroup namespaces                                                        
✓ RestrictNamespaces=~CLONE_NEWIPC                            Service cannot create IPC namespaces                                                           
✓ RestrictNamespaces=~CLONE_NEWNET                            Service cannot create network namespaces                                                       
✓ RestrictNamespaces=~CLONE_NEWNS                             Service cannot create file system namespaces                                                   
✓ RestrictNamespaces=~CLONE_NEWPID                            Service cannot create process namespaces                                                       
✓ RestrictRealtime=                                           Service realtime scheduling access is restricted                                               
✓ SystemCallFilter=~@cpu-emulation                            System call allow list defined for service, and @cpu-emulation is not included                 
✓ SystemCallFilter=~@obsolete                                 System call allow list defined for service, and @obsolete is not included                      
✓ RestrictAddressFamilies=~AF_NETLINK                         Service cannot allocate netlink sockets                                                        
✗ RootDirectory=/RootImage=                                   Service runs within the host's root directory                                               0.1
  SupplementaryGroups=                                        Service runs as root, option does not matter                                                   
✓ CapabilityBoundingSet=~CAP_MAC_*                            Service cannot adjust SMACK MAC                                                                
✓ CapabilityBoundingSet=~CAP_SYS_BOOT                         Service cannot issue reboot()                                                                  
✓ Delegate=                                                   Service does not maintain its own delegated control group subtree                              
✓ LockPersonality=                                            Service cannot change ABI personality                                                          
✓ MemoryDenyWriteExecute=                                     Service cannot create writable executable memory mappings                                      
  RemoveIPC=                                                  Service runs as root, option does not apply                                                    
✓ RestrictNamespaces=~CLONE_NEWUTS                            Service cannot create hostname namespaces                                                      
✗ UMask=                                                      Files created by service are world-readable by default                                      0.1
✓ CapabilityBoundingSet=~CAP_LINUX_IMMUTABLE                  Service cannot mark files immutable                                                            
✓ CapabilityBoundingSet=~CAP_IPC_LOCK                         Service cannot lock memory into RAM                                                            
✓ CapabilityBoundingSet=~CAP_SYS_CHROOT                       Service cannot issue chroot()                                                                  
✓ ProtectHostname=                                            Service cannot change system host/domainname                                                   
✓ CapabilityBoundingSet=~CAP_BLOCK_SUSPEND                    Service cannot establish wake locks                                                            
✓ CapabilityBoundingSet=~CAP_LEASE                            Service cannot create file leases                                                              
✓ CapabilityBoundingSet=~CAP_SYS_PACCT                        Service cannot use acct()                                                                      
✓ CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG                   Service cannot issue vhangup()                                                                 
✓ CapabilityBoundingSet=~CAP_WAKE_ALARM                       Service cannot program timers that wake up the system                                          
✓ RestrictAddressFamilies=~AF_UNIX                            Service cannot allocate local sockets                                                          
✗ ProcSubset=                                                 Service has full access to non-process /proc files (/proc subset=)                          0.1

→ Overall exposure level for update-geoipsets.service: 2.1 OK 🙂
```
Fixes #18 