### PR TITLE
Add checksum validation for dbip

### DIFF
--- a/python/geoipsets.conf
+++ b/python/geoipsets.conf
@@ -17,6 +17,12 @@ firewall=iptables,nftables
 # if the property doesn't exist or exists, but is empty, ipv4 sets will be generated (default)
 address-family=ipv4,ipv6
 
+# whether or not to validate the checksum of downloaded files
+# this option exists because the dbip checksums are only available via screen scrape, which can be brittle
+# if the webpage layout changes and breaks checksum validation, set this to 'False' for processing to continue
+# applies to the MaxMind provider type as well for consistency
+checksum=True
+
 # specify which countries to build sets for
 # countries are specified using the 2-character country codes, one per line
 # https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2

--- a/python/geoipsets.conf
+++ b/python/geoipsets.conf
@@ -17,12 +17,6 @@ firewall=iptables,nftables
 # if the property doesn't exist or exists, but is empty, ipv4 sets will be generated (default)
 address-family=ipv4,ipv6
 
-# whether or not to validate the checksum of downloaded files
-# this option exists because the dbip checksums are only available via screen scrape, which can be brittle
-# if the webpage layout changes and breaks checksum validation, set this to 'False' for processing to continue
-# applies to the MaxMind provider type as well for consistency
-checksum=True
-
 # specify which countries to build sets for
 # countries are specified using the 2-character country codes, one per line
 # https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2

--- a/python/geoipsets/__main__.py
+++ b/python/geoipsets/__main__.py
@@ -1,7 +1,7 @@
 # __main__.py
 
 import configparser
-from argparse import ArgumentParser, BooleanOptionalAction
+from argparse import ArgumentParser
 from configparser import ConfigParser
 from pathlib import Path
 from sys import argv
@@ -76,9 +76,15 @@ def get_config(cli_args=None):
                         type=str,
                         default=default_config_path,
                         help="path to configuration file (default: {0})".format(default_config_path))
-    parser.add_argument("-k", "--checksum",
-                        action=BooleanOptionalAction,
-                        help="enable/disable checksum validation of downloaded files (default: True)")
+    parser.add_argument("--checksum",
+                        dest="checksum",
+                        action="store_true",
+                        help="enable checksum validation of downloaded files (default)")
+    parser.add_argument("--no-checksum",
+                        dest="checksum",
+                        action="store_false",
+                        help="disable checksum validation of downloaded files")
+    parser.set_defaults(checksum=True)
 
     # set defaults
     default_options = dict()
@@ -86,7 +92,7 @@ def get_config(cli_args=None):
     default_options['firewall'] = {utils.Firewall.NF_TABLES.value}
     default_options['address-family'] = {utils.AddressFamily.IPV4.value}
     default_options['countries'] = 'all'
-    default_options['checksum'] = True
+    default_options['checksum'] = parser.parse_args(cli_args).checksum
     options = default_options
 
     # step 1: load a valid configuration file, if one exists
@@ -123,16 +129,7 @@ def get_config(cli_args=None):
             if (address_family := general.get('address-family')) is not None:
                 options['address-family'] = set(address_family.split(','))
 
-    # step 5: checksum
-    if (checksum := parser.parse_args(cli_args).checksum) is not None:
-        options['checksum'] = checksum
-    else:
-        if valid_conf_file and config_file.has_section('general'):
-            general = config_file['general']
-            if (checksum := general.getboolean('checksum')) is not None:
-                options['checksum'] = checksum
-
-    # step 6: countries
+    # step 5: countries
     if (country_arg := parser.parse_args(cli_args).countries) is not None:
         country_set = set()
         try:
@@ -159,14 +156,14 @@ def get_config(cli_args=None):
             if len(countries) > 0:
                 options['countries'] = countries
 
-    # step 7: provider options
+    # step 6: provider options
     if valid_conf_file:
         for p in options.get('provider'):
             if config_file.has_section(p):
                 provider_options = config_file[p]
                 options[p] = provider_options
 
-    # step 8: output path
+    # step 7: output path
     options['output-dir'] = parser.parse_args(cli_args).output_dir
     return options
 

--- a/python/geoipsets/dbip.py
+++ b/python/geoipsets/dbip.py
@@ -176,7 +176,10 @@ class DbIpProvider(utils.AbstractProvider):
 
         # calculate the sha1sum of the downloaded file
         sha1_hash = hashlib.sha1()
-        sha1_hash.update(csv_file_bytes.read())
+        # Read and update hash in 8K chunks
+        while chunk := csv_file_bytes.read(8192):
+            sha1_hash.update(chunk)
+
         computed_sha1sum = sha1_hash.hexdigest()
 
         # reset position to beginning of file now that we're done

--- a/python/geoipsets/utils.py
+++ b/python/geoipsets/utils.py
@@ -18,14 +18,15 @@ class AddressFamily(Enum):
 class AbstractProvider(ABC):
     """Abstract base class providing common functionality for all Provider types."""
 
-    def __init__(self, firewall: set, address_family: set, countries: set, output_dir: str):
+    def __init__(self, firewall: set, address_family: set, checksum: bool, countries: set, output_dir: str):
         self.ipv4 = AddressFamily.IPV4.value in address_family
         self.ipv6 = AddressFamily.IPV6.value in address_family
         self.nf_tables = Firewall.NF_TABLES.value in firewall
         self.ip_tables = Firewall.IP_TABLES.value in firewall
+        self.checksum = checksum
         self.countries = countries
         self.base_dir = Path(output_dir) / 'geoipsets'
 
-        @abstractmethod
-        def generate():
-            pass
+    @abstractmethod
+    def generate(self):
+        pass

--- a/python/setup.py
+++ b/python/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     packages=find_packages(exclude=("tests",)),
     include_package_data=True,
-    install_requires=["requests"],
+    install_requires=["requests", "beautifulsoup4"],
     entry_points={
         "console_scripts": [
             "geoipsets=geoipsets.__main__:main",

--- a/python/tests/config_test.py
+++ b/python/tests/config_test.py
@@ -196,7 +196,6 @@ def test_config_file_non_defaults(option, value, monkeypatch):
             """
             [general]
             {0}={1}
-            checksum=False
             [countries]
             CA
             """.format(option, value))
@@ -206,7 +205,6 @@ def test_config_file_non_defaults(option, value, monkeypatch):
 
     config = __main__.get_config(['-c', '/tmp/dummy.conf'])
     assert config.get(option) == {value}
-    assert not config.get('checksum')
     assert config.get('countries') == {'ca'}
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 setuptools>=51.1.2
 requests>=2.25.1
 pytest>=6.2.5
+beautifulsoup4>=4.10


### PR DESCRIPTION
The valid checksum is pulled directly from the `dbip` webpage via screen scrape as its not available as a direct download. For this reason a new command line flag (`--checksum/--no-checksum`) has been added. In the event a change in the webpage breaks checksum validation, the `--no-checksum` flag will allow `geoipsets` to continue working.

For consistency the flags apply to `MaxMind` as well.

This is a command line flag only and is not honoured when present in the configuration file.

Fixes #12 