### PR TITLE
dbip performance improvements

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -16,26 +16,27 @@ Typically, you would want to select only one firewall type along with a short li
 The utility will attempt to read the configuration file at */etc/geoipsets.conf* but the location can be overidden using the *--config PATH_TO_FILE* command line option.
 
 ```shell
-usage: geoipsets [-h] [-v] [-p {maxmind,dbip} [{maxmind,dbip} ...]] [-f {nftables,iptables} [{nftables,iptables} ...]] [-a {ipv6,ipv4} [{ipv6,ipv4} ...]]
-                 [-l COUNTRIES] [-o OUTPUT_DIR] [-c CONFIG_FILE]
+usage: geoipsets [-h] [-v] [-p {dbip,maxmind} [{dbip,maxmind} ...]] [-f {iptables,nftables} [{iptables,nftables} ...]] [-a {ipv6,ipv4} [{ipv6,ipv4} ...]]
+                 [-l COUNTRIES] [-o OUTPUT_DIR] [-c CONFIG_FILE] [--checksum] [--no-checksum]
 
 Utility to build country specific IP sets for ipset/iptables and nftables. Command line arguments take precedence over those in the configuration file.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -p {maxmind,dbip} [{maxmind,dbip} ...], --provider {maxmind,dbip} [{maxmind,dbip} ...]
+  -p {dbip,maxmind} [{dbip,maxmind} ...], --provider {dbip,maxmind} [{dbip,maxmind} ...]
                         dataset provider(s) (default: dbip)
-  -f {nftables,iptables} [{nftables,iptables} ...], --firewall {nftables,iptables} [{nftables,iptables} ...]
+  -f {iptables,nftables} [{iptables,nftables} ...], --firewall {iptables,nftables} [{iptables,nftables} ...]
                         firewall(s) to build sets for (default: nftables)
   -a {ipv6,ipv4} [{ipv6,ipv4} ...], --address-family {ipv6,ipv4} [{ipv6,ipv4} ...]
                         IP protocol(s) to build sets for (default: ipv4)
   -l COUNTRIES, --countries COUNTRIES
-                        Path to a file containing 2-char ISO country codes, one per line, or a comma-separated list of country codes. Argument is treated as a path
-                        first. If it does not resolve, or the resolved file is invalid, then it is parsed as a comma-separated list.
+                        Path to a file containing 2-character country codes, one per line, or a comma-separated list of country codes. Argument is treated
+                        as a path first. If it does not resolve, or the resolved file is invalid, then it is parsed as a comma-separated list.
   -o OUTPUT_DIR, --output-dir OUTPUT_DIR
                         directory where geoipsets should be saved (default: /tmp)
   -c CONFIG_FILE, --config-file CONFIG_FILE
                         path to configuration file (default: /etc/geoipsets.conf)
-
+  --checksum            enable checksum validation of downloaded files (default)
+  --no-checksum         disable checksum validation of downloaded files
 ```

--- a/python/geoipsets.conf
+++ b/python/geoipsets.conf
@@ -9,12 +9,12 @@ provider=dbip,maxmind
 # valid values are: 'iptables', 'nftables'
 # iptables: builds 'ipset' compatible sets
 # nftables: builds nftables compatible sets
-# if the property doesn't exist, or exists but is empty, nftables sets are generated (default)
+# default: nftables
 firewall=iptables,nftables
 
 # list of IP protocols to build sets for
 # valid values are: 'ipv4', 'ipv6'
-# if the property doesn't exist or exists, but is empty, ipv4 sets will be generated (default)
+# default: ipv4
 address-family=ipv4,ipv6
 
 # specify which countries to build sets for

--- a/python/geoipsets/dbip.py
+++ b/python/geoipsets/dbip.py
@@ -51,11 +51,18 @@ class DbIpProvider(utils.AbstractProvider):
                         inet_suffix = 'ipv' + str(ip_version)
                         filename_key = cc + '.' + inet_suffix
                         ip_end = ip_address(r['ip_end'])
-                        subnets = [nets.with_prefixlen for nets in summarize_address_range(ip_start, ip_end)]
-                        if filename_key in country_subnets:  # append
-                            country_subnets[filename_key].extend(subnets)
-                        else:  # create
-                            country_subnets[filename_key] = subnets
+                        if self.ip_tables:  # https://github.com/chr0mag/geoipsets/issues/25
+                            subnets = [nets.with_prefixlen for nets in summarize_address_range(ip_start, ip_end)]
+                            if filename_key in country_subnets:  # append
+                                country_subnets[filename_key].extend(subnets)
+                            else:  # create
+                                country_subnets[filename_key] = subnets
+                        else:  # conversion not required for nftables
+                            ip_range = r['ip_start'] + '-' + r['ip_end']
+                            if filename_key in country_subnets:  # append
+                                country_subnets[filename_key].append(ip_range)
+                            else:  # create
+                                country_subnets[filename_key] = [ip_range]
 
         self.build_sets(country_subnets)
 


### PR DESCRIPTION
When only the `nftables` firewall type is selected, `geoipsets` will avoid converting `dbip` data to CIDR notation and simply pass the IP ranges directly to `nftables` without modification. This results in a ~50% performance improvement.
```
# before
[tags/v2.3.2] % time python -m geoipsets --provider dbip --firewall nftables --config-file ~/geoipsets.conf
Building geoipsets...
python -m geoipsets --provider dbip --firewall nftables --config-file   11.66s user 0.07s system 94% cpu 12.387 total

# after
[dbip-perf] % time python -m geoipsets --provider dbip --firewall nftables --config-file ~/geoipsets.conf
Building geoipsets...
python -m geoipsets --provider dbip --firewall nftables --config-file   5.07s user 0.07s system 88% cpu 5.789 total
```
Fixes #25 

Also includes a small change to only delete existing sets if the current run will re-create them. Otherwise they are left untouched. This brings the behaviour of the `dbip` provider inline with the `MaxMind` provider.