### PR TITLE
fix: remove default arg for output-dir in parser

### DIFF
--- a/python/geoipsets/__main__.py
+++ b/python/geoipsets/__main__.py
@@ -70,7 +70,6 @@ def get_config(cli_args=None):
                              the resolved file is invalid, then it is parsed as a comma-separated list.""")
     parser.add_argument("-o", "--output-dir",
                         type=str,
-                        default=default_output_dir,
                         help="directory where geoipsets should be saved (default: {0})".format(default_output_dir))
     parser.add_argument("-c", "--config-file",
                         type=str,


### PR DESCRIPTION
## Problem description
When `geoipsets` is called without arguments and a config file installed in `/etc/geoipsets.conf` the `output-dir` in the config file is ignored.

This is fixed by removing the default argument in the parser.
The default argument for output-dir gets handled by subsequent control flow. (step 2)